### PR TITLE
getBranchNumber nullable return type

### DIFF
--- a/src/Client/Profile/Company.php
+++ b/src/Client/Profile/Company.php
@@ -69,7 +69,7 @@ final class Company
         return $this->kvkNumber;
     }
 
-    public function getBranchNumber(): string
+    public function getBranchNumber(): ?string
     {
         return $this->branchNumber;
     }


### PR DESCRIPTION
As the constructor allows the branchNumber to be null. The getter should have a nullable return type.