### PR TITLE
Can't mock KvkClient because the class is marked final

### DIFF
--- a/src/KvkClient.php
+++ b/src/KvkClient.php
@@ -9,9 +9,9 @@ use Werkspot\KvkApi\Client\KvkPaginator;
 use Werkspot\KvkApi\Client\KvkPaginatorInterface;
 use Werkspot\KvkApi\Http\ClientInterface;
 use Werkspot\KvkApi\Http\Endpoint\MapperInterface;
-use Werkspot\KvkApi\Http\Search\ProfileQuery;
+use Werkspot\KvkApi\Http\Search\QueryInterface;
 
-final class KvkClient
+final class KvkClient implements KvkClientInterface, KvkPaginatorAwareInterface
 {
     /**
      * @var ClientInterface
@@ -29,7 +29,7 @@ final class KvkClient
         $this->profileResponseFactory = $profileResponseFactory;
     }
 
-    public function getProfile(ProfileQuery $profileQuery): KvkPaginatorInterface
+    public function getProfile(QueryInterface $profileQuery): KvkPaginatorInterface
     {
         $json = $this->httpClient->getJson($this->httpClient->getEndpoint(MapperInterface::PROFILE, $profileQuery));
         $data = $this->decodeJsonToArray($json);

--- a/src/KvkClientInterface.php
+++ b/src/KvkClientInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Werkspot\KvkApi;
+
+use Werkspot\KvkApi\Client\KvkPaginatorInterface;
+use Werkspot\KvkApi\Http\Search\QueryInterface;
+
+interface KvkClientInterface
+{
+    public function getProfile(QueryInterface $profileQuery): KvkPaginatorInterface;
+}
+

--- a/src/KvkPaginatorAwareInterface.php
+++ b/src/KvkPaginatorAwareInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Werkspot\KvkApi;
+
+use Werkspot\KvkApi\Client\KvkPaginatorInterface;
+
+interface KvkPaginatorAwareInterface
+{
+    public function getNextPage(KvkPaginatorInterface $kvkPaginator): KvkPaginatorInterface;
+    public function getPreviousPage(KvkPaginatorInterface $kvkPaginator): KvkPaginatorInterface;
+}


### PR DESCRIPTION
Removed final keyword from class definition so that we can mock this class.

Devs implementing this library in their projects are likely to want to mock this class in their tests.